### PR TITLE
feat(demo): add 'current_sign_in_at' column to users models

### DIFF
--- a/projects/demo/models/intermediate/users/int_users.sql
+++ b/projects/demo/models/intermediate/users/int_users.sql
@@ -16,6 +16,7 @@ SELECT
         ELSE 'Plus de 10 fois'
         END
     ) AS sign_in_frequency,
+    decidim_users.current_sign_in_at,
     decidim_users.last_sign_in_at,
     decidim_users.created_at,
     decidim_users.updated_at,

--- a/projects/demo/models/marts/users/all_users.sql
+++ b/projects/demo/models/marts/users/all_users.sql
@@ -59,6 +59,7 @@ SELECT
     decidim_users.email,
     decidim_users.sign_in_count,
     decidim_users.sign_in_frequency,
+    decidim_users.current_sign_in_at,
     decidim_users.last_sign_in_at,
     decidim_users.created_at,
     decidim_users.updated_at,

--- a/projects/demo/models/marts/users/users.sql
+++ b/projects/demo/models/marts/users/users.sql
@@ -3,6 +3,7 @@ SELECT
     decidim_users.email,
     decidim_users.sign_in_count,
     decidim_users.sign_in_frequency,
+    decidim_users.current_sign_in_at,
     decidim_users.last_sign_in_at,
     decidim_users.created_at,
     decidim_users.updated_at,

--- a/projects/demo/models/staging/decidim/stg_decidim_users.sql
+++ b/projects/demo/models/staging/decidim/stg_decidim_users.sql
@@ -6,6 +6,7 @@ renamed AS (
         id,
         email,
         sign_in_count,
+        current_sign_in_at,
         last_sign_in_at,
         created_at,
         updated_at,


### PR DESCRIPTION
Why was it removed?